### PR TITLE
Edited lib/sluggable_finder.rb via GitHub

### DIFF
--- a/lib/sluggable_finder.rb
+++ b/lib/sluggable_finder.rb
@@ -19,7 +19,7 @@ module SluggableFinder
       ActiveRecord::Base.extend SluggableFinder::Orm::ClassMethods
       # support for associations
       a = ActiveRecord::Associations
-      returning([ a::AssociationCollection ]) { |classes|
+      tap([ a::AssociationCollection ]) { |classes|
         # detect http://dev.rubyonrails.org/changeset/9230
         unless a::HasManyThroughAssociation.superclass == a::HasManyAssociation
           classes << a::HasManyThroughAssociation


### PR DESCRIPTION
Could you change returning to tap which is a native Ruby Object#tap rather then using rails extension which is depricated :)

Thanks! Cheers
